### PR TITLE
id:3852 Changes Release and Version strings in plugin documentation.

### DIFF
--- a/data/System/FilesysVirtualPlugin.txt
+++ b/data/System/FilesysVirtualPlugin.txt
@@ -94,8 +94,8 @@ Many thanks to the following sponsors for supporting this work:
 |  Author(s): | Crawford Currie http://c-dot.co.uk |
 |  Copyright: | &copy; 2008 !KontextWork.de, &copy; 2008-2013 Crawford Currie http://c-dot.co.uk |
 |  License: | [[http://www.gnu.org/licenses/old-licenses/gpl-2.0.html][GPL2 (Gnu General Public License v2)]] |
-|  Release: | /jidQrcaozxnxTDSHEh3qA |
-|  Version: | 1.6.2 |
+|  Release: | %$RELEASE% |
+|  Version: | %$VERSION% |
 |  Change History: | <!-- versions below in reverse order -->&nbsp; |
 |  Dependencies: | <table class="foswikiTable" border="1"><tr><th>Name</th><th>Version</th><th>Description</th></tr><tr><td align="left">Filesys::Virtual</td><td align="left">&gt;=0</td><td align="left">Standard perl module</td></tr><tr><td align="left">Storable</td><td align="left">&gt;=0</td><td align="left">Required, used for the locks database</td></tr><tr><td align="left">POSIX</td><td align="left">&gt;=0</td><td align="left">Standard perl module</td></tr><tr><td align="left">File::Path</td><td align="left">&gt;=0</td><td align="left">Standard perl module</td></tr><tr><td align="left">IO::File</td><td align="left">&gt;=0</td><td align="left">Standard perl module</td></tr><tr><td align="left">IO::String</td><td align="left">&gt;=0</td><td align="left">Standard perl module</td></tr><tr><td align="left">Foswiki::Plugins::WysiwygPlugin</td><td align="left">&gt;=0</td><td align="left">Optional, required for .html view</td></tr><tr><td align="left">JSON</td><td align="left">&gt;=0</td><td align="left">Optional, required for the .json view</td></tr></table> |
 


### PR DESCRIPTION
This is changed to get correct release strings when building and deploying via RMS.

Ticket: none

Release-Note: none